### PR TITLE
Add support for fixed gap masking

### DIFF
--- a/src/models/mae_vit.py
+++ b/src/models/mae_vit.py
@@ -84,39 +84,37 @@ class MAEEncoder(nn.Module):
         trunc_normal_(self.cls_token, std=.02)
         trunc_normal_(self.pos_embedding, std=.02)
     
-    def forward(self, img: torch.Tensor, apply_mask: bool = True) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """
-        Forward pass through the encoder.
-        
+    def forward(
+        self,
+        img: torch.Tensor,
+        mask_bounds: Optional[Tuple[int, int]] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Forward pass through the encoder.
+
         Args:
-            img: Input spectrogram
-            apply_mask: Whether to apply masking
-            
+            img: Input spectrogram.
+            mask_bounds: Optional tuple ``(start, end)`` specifying the start and
+                end column (in pixel indices) of an already-masked region. If
+                ``None``, a random region will be masked.
+
         Returns:
             Tuple containing:
                 - Encoded features
                 - Backward indexes
-                - Masked image (if apply_mask=True) or original image (if apply_mask=False)
+                - Masked image corresponding to ``mask_bounds``
         """
-        if not apply_mask:
-            patches = self.patchify(img)
-            patches = rearrange(patches, 'b c h w -> (h w) b c')
-            patches = patches + self.pos_embedding
-            T, B, _ = patches.shape
-            identity_bwd = torch.arange(T, device=patches.device).unsqueeze(1).repeat(1, B)
-            
-            patches = torch.cat([self.cls_token.expand(-1, patches.shape[1], -1), patches], dim=0)
-            patches = rearrange(patches, 't b c -> b t c')
-            features = self.layer_norm(self.transformer(patches))
-            features = rearrange(features, 'b t c -> t b c')
-            
-            return features, identity_bwd, img
-        
         patches = self.patchify(img)
         patches = rearrange(patches, 'b c h w -> (h w) b c')
         patches = patches + self.pos_embedding
-        
-        patches, forward_indexes, backward_indexes, stripe_bounds = self.shuffle(patches)
+
+        if mask_bounds is not None:
+            start_pix, end_pix = mask_bounds
+            start_patch = start_pix // self.patch_size
+            end_patch = (end_pix + self.patch_size - 1) // self.patch_size
+            bounds = torch.tensor([[start_patch], [end_patch]], device=patches.device).repeat(1, patches.shape[1])
+            patches, forward_indexes, backward_indexes, stripe_bounds = self.shuffle(patches, bounds)
+        else:
+            patches, forward_indexes, backward_indexes, stripe_bounds = self.shuffle(patches)
         
         patches = torch.cat([self.cls_token.expand(-1, patches.shape[1], -1), patches], dim=0)
         patches = rearrange(patches, 't b c -> b t c')
@@ -287,17 +285,23 @@ class MAEViT(BaseModel):
         #         f"Image size {image_size} must be divisible by patch size {patch_size}"
         #     )
     
-    def forward(self, img: torch.Tensor, apply_mask: bool = True) -> Tuple[torch.Tensor, torch.Tensor]:
-        """
-        Forward pass through the MAE model.
+    def forward(
+        self,
+        img: torch.Tensor,
+        mask_bounds: Optional[Tuple[int, int]] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Forward pass through the MAE model.
+
         Args:
-            img: Input spectrogram
-            apply_mask: Whether to apply masking during encoding
+            img: Input spectrogram.
+            mask_bounds: Optional tuple ``(start, end)`` describing the region to
+                mask (in pixel indices). If ``None``, a random region is masked.
+
         Returns:
             Tuple containing:
                 - Reconstructed spectrogram
                 - Mask indicating which patches were masked
         """
-        features, backward_indexes, full_mask = self.encoder(img, apply_mask=apply_mask)
+        features, backward_indexes, _ = self.encoder(img, mask_bounds=mask_bounds)
         predicted_img, mask = self.decoder(features, backward_indexes)
         return predicted_img, mask

--- a/src/models/patch_shuffle.py
+++ b/src/models/patch_shuffle.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn as nn
 import numpy as np
 import random
-from typing import Tuple
+from typing import Tuple, Optional
 from einops import repeat
 
 
@@ -44,13 +44,19 @@ class PatchShuffle(nn.Module):
         self.num_rows = num_rows
         self.num_cols = num_cols
     
-    def forward(self, patches: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        """
-        Forward pass for patch shuffling.
-        
+    def forward(
+        self,
+        patches: torch.Tensor,
+        bounds: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Forward pass for patch shuffling.
+
         Args:
-            patches: Input patches with shape [T, B, C] where T = num_rows * num_cols
-            
+            patches: Input patches with shape ``[T, B, C]`` where ``T = num_rows * num_cols``.
+            bounds: Optional tensor specifying the start and end column (in patch
+                indices) to mask for each sample. Shape should be ``[2, B]``.
+                If ``None``, a random start column is used.
+
         Returns:
             Tuple containing:
                 - Shuffled patches
@@ -70,10 +76,15 @@ class PatchShuffle(nn.Module):
         # Pre-compute a (r, c) grid of flattened indices
         grid = torch.arange(T, device=device).view(r, c)  # shape [r, c]
         
-        for _ in range(B):
-            # Choose random start col
-            start_col = random.randint(0, c - stripe_width)
-            end_col = start_col + stripe_width
+        for b in range(B):
+            if bounds is not None:
+                start_col = int(bounds[0, b].item())
+                end_col = int(bounds[1, b].item())
+                start_col = max(0, min(start_col, c - 1))
+                end_col = max(start_col + 1, min(end_col, c))
+            else:
+                start_col = random.randint(0, c - stripe_width)
+                end_col = start_col + stripe_width
             
             # Visible = columns outside stripe
             visible_cols_left = grid[:, :start_col].flatten()

--- a/src/training/mae_trainer.py
+++ b/src/training/mae_trainer.py
@@ -200,9 +200,8 @@ class MAETrainer(BaseTrainer):
                     print(f"⚠️ Skipping validation sample {i}: empty gap range")
                     continue
                 
-                # Forward pass
-                features, backward_indexes, _ = self.model.encoder(gap_slice, apply_mask=False) # type: ignore
-                predicted, mask = self.model.decoder(features, backward_indexes) # type: ignore
+                # Forward pass with masking on the real gap
+                predicted, mask = self.model(gap_slice, mask_bounds=(gap_start, gap_end))
                 
                 # Compute loss only on gap region
                 gap_region_target = target[:, :, :, gap_start:gap_end]


### PR DESCRIPTION
## Summary
- allow `PatchShuffle` to take explicit mask bounds
- update MAE encoder/decoder to use optional `mask_bounds`
- mask the real gap during validation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*
- `pip install einops timm librosa PyYAML tensorboard --quiet` *(blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688a3c10608c832db073b45887b03ab2