### PR TITLE
Add additional config variants for loss weight & masking

### DIFF
--- a/configs/mask025_l1_01.yaml
+++ b/configs/mask025_l1_01.yaml
@@ -1,0 +1,28 @@
+model:
+  emb_dim: 768
+  encoder_layer: 2
+  encoder_head: 4
+  decoder_layer: 2
+  decoder_head: 4
+  pretrained_ViT: true
+  patch_size: 4
+training:
+  seed: 42
+  batch_size: 4
+  max_device_batch_size: 512
+  base_learning_rate: 0.00015
+  weight_decay: 0.05
+  mask_ratio: 0.25
+  total_epoch: 50
+  warmup_epoch: 1
+  l1_weight: 0.1
+  resume: false
+paths:
+  model_path: vit-t-mae.pt
+  audio_filename: assets/gapped_audio.wav
+  test_audio_filename: assets/wav_test.wav
+  log_dir: runs
+  
+# Data settings
+data:
+  n_mels: 80

--- a/configs/mask025_l1_03.yaml
+++ b/configs/mask025_l1_03.yaml
@@ -1,0 +1,28 @@
+model:
+  emb_dim: 768
+  encoder_layer: 2
+  encoder_head: 4
+  decoder_layer: 2
+  decoder_head: 4
+  pretrained_ViT: true
+  patch_size: 4
+training:
+  seed: 42
+  batch_size: 4
+  max_device_batch_size: 512
+  base_learning_rate: 0.00015
+  weight_decay: 0.05
+  mask_ratio: 0.25
+  total_epoch: 50
+  warmup_epoch: 1
+  l1_weight: 0.3
+  resume: false
+paths:
+  model_path: vit-t-mae.pt
+  audio_filename: assets/gapped_audio.wav
+  test_audio_filename: assets/wav_test.wav
+  log_dir: runs
+  
+# Data settings
+data:
+  n_mels: 80

--- a/configs/mask050_l1_01.yaml
+++ b/configs/mask050_l1_01.yaml
@@ -1,0 +1,28 @@
+model:
+  emb_dim: 768
+  encoder_layer: 2
+  encoder_head: 4
+  decoder_layer: 2
+  decoder_head: 4
+  pretrained_ViT: true
+  patch_size: 4
+training:
+  seed: 42
+  batch_size: 4
+  max_device_batch_size: 512
+  base_learning_rate: 0.00015
+  weight_decay: 0.05
+  mask_ratio: 0.50
+  total_epoch: 50
+  warmup_epoch: 1
+  l1_weight: 0.1
+  resume: false
+paths:
+  model_path: vit-t-mae.pt
+  audio_filename: assets/gapped_audio.wav
+  test_audio_filename: assets/wav_test.wav
+  log_dir: runs
+  
+# Data settings
+data:
+  n_mels: 80

--- a/configs/mask050_l1_03.yaml
+++ b/configs/mask050_l1_03.yaml
@@ -1,0 +1,28 @@
+model:
+  emb_dim: 768
+  encoder_layer: 2
+  encoder_head: 4
+  decoder_layer: 2
+  decoder_head: 4
+  pretrained_ViT: true
+  patch_size: 4
+training:
+  seed: 42
+  batch_size: 4
+  max_device_batch_size: 512
+  base_learning_rate: 0.00015
+  weight_decay: 0.05
+  mask_ratio: 0.50
+  total_epoch: 50
+  warmup_epoch: 1
+  l1_weight: 0.3
+  resume: false
+paths:
+  model_path: vit-t-mae.pt
+  audio_filename: assets/gapped_audio.wav
+  test_audio_filename: assets/wav_test.wav
+  log_dir: runs
+  
+# Data settings
+data:
+  n_mels: 80

--- a/configs/mask075_l1_01.yaml
+++ b/configs/mask075_l1_01.yaml
@@ -1,0 +1,28 @@
+model:
+  emb_dim: 768
+  encoder_layer: 2
+  encoder_head: 4
+  decoder_layer: 2
+  decoder_head: 4
+  pretrained_ViT: true
+  patch_size: 4
+training:
+  seed: 42
+  batch_size: 4
+  max_device_batch_size: 512
+  base_learning_rate: 0.00015
+  weight_decay: 0.05
+  mask_ratio: 0.75
+  total_epoch: 50
+  warmup_epoch: 1
+  l1_weight: 0.1
+  resume: false
+paths:
+  model_path: vit-t-mae.pt
+  audio_filename: assets/gapped_audio.wav
+  test_audio_filename: assets/wav_test.wav
+  log_dir: runs
+  
+# Data settings
+data:
+  n_mels: 80

--- a/configs/mask075_l1_03.yaml
+++ b/configs/mask075_l1_03.yaml
@@ -1,0 +1,28 @@
+model:
+  emb_dim: 768
+  encoder_layer: 2
+  encoder_head: 4
+  decoder_layer: 2
+  decoder_head: 4
+  pretrained_ViT: true
+  patch_size: 4
+training:
+  seed: 42
+  batch_size: 4
+  max_device_batch_size: 512
+  base_learning_rate: 0.00015
+  weight_decay: 0.05
+  mask_ratio: 0.75
+  total_epoch: 50
+  warmup_epoch: 1
+  l1_weight: 0.3
+  resume: false
+paths:
+  model_path: vit-t-mae.pt
+  audio_filename: assets/gapped_audio.wav
+  test_audio_filename: assets/wav_test.wav
+  log_dir: runs
+  
+# Data settings
+data:
+  n_mels: 80


### PR DESCRIPTION
## Summary
- add new experiment configs in `configs/` exploring mask ratios 0.25/0.50/0.75
- vary L1 loss weighting between 0.1 and 0.3

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_688b65cc4b04832d9469989e39b3e906