### PR TITLE
Add optional Muon optimizer support

### DIFF
--- a/clean_requirements.txt
+++ b/clean_requirements.txt
@@ -219,3 +219,4 @@ widgetsnbextension
 wrapt==1.17.2
 zipp 
 zstandard==0.23.0
+muon-optimizer @ git+https://github.com/KellerJordan/Muon

--- a/configs/debug.yaml
+++ b/configs/debug.yaml
@@ -16,6 +16,7 @@ training:
   total_epoch: 2
   warmup_epoch: 1
   l1_weight: 0.0
+  use_muon: false
   resume: false
 paths:
   model_path: vit-t-mae.pt

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -16,6 +16,7 @@ training:
   total_epoch: 50
   warmup_epoch: 1
   l1_weight: 0.0
+  use_muon: false
   resume: false
 paths:
   model_path: vit-t-mae.pt

--- a/configs/mask025_l1_01.yaml
+++ b/configs/mask025_l1_01.yaml
@@ -16,6 +16,7 @@ training:
   total_epoch: 50
   warmup_epoch: 1
   l1_weight: 0.1
+  use_muon: false
   resume: false
 paths:
   model_path: vit-t-mae.pt

--- a/configs/mask025_l1_03.yaml
+++ b/configs/mask025_l1_03.yaml
@@ -16,6 +16,7 @@ training:
   total_epoch: 50
   warmup_epoch: 1
   l1_weight: 0.3
+  use_muon: false
   resume: false
 paths:
   model_path: vit-t-mae.pt

--- a/configs/mask050_l1_01.yaml
+++ b/configs/mask050_l1_01.yaml
@@ -16,6 +16,7 @@ training:
   total_epoch: 50
   warmup_epoch: 1
   l1_weight: 0.1
+  use_muon: false
   resume: false
 paths:
   model_path: vit-t-mae.pt

--- a/configs/mask050_l1_03.yaml
+++ b/configs/mask050_l1_03.yaml
@@ -16,6 +16,7 @@ training:
   total_epoch: 50
   warmup_epoch: 1
   l1_weight: 0.3
+  use_muon: false
   resume: false
 paths:
   model_path: vit-t-mae.pt

--- a/configs/mask075_l1_01.yaml
+++ b/configs/mask075_l1_01.yaml
@@ -16,6 +16,7 @@ training:
   total_epoch: 50
   warmup_epoch: 1
   l1_weight: 0.1
+  use_muon: false
   resume: false
 paths:
   model_path: vit-t-mae.pt

--- a/configs/mask075_l1_03.yaml
+++ b/configs/mask075_l1_03.yaml
@@ -16,6 +16,7 @@ training:
   total_epoch: 50
   warmup_epoch: 1
   l1_weight: 0.3
+  use_muon: false
   resume: false
 paths:
   model_path: vit-t-mae.pt

--- a/requirements.txt
+++ b/requirements.txt
@@ -219,3 +219,4 @@ widgetsnbextension @ file:///home/conda/feedstock_root/build_artifacts/widgetsnb
 wrapt==1.17.2
 zipp @ file:///home/conda/feedstock_root/build_artifacts/zipp_1732827521216/work
 zstandard==0.23.0
+muon-optimizer @ git+https://github.com/KellerJordan/Muon

--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -185,6 +185,7 @@ class ConfigManager:
             'warmup_epoch': self.get('training.warmup_epoch', 1),
             'save_every': self.get('training.save_every', 10),
             'resume': self.get('training.resume', False),
+            'use_muon': self.get('training.use_muon', False),
             'log_dir': self.get('paths.log_dir', None),
             'l1_weight': self.get('training.l1_weight', 0.0),
             'mask_ratio': self.get('training.mask_ratio', 0.75),

--- a/src/training/mae_trainer.py
+++ b/src/training/mae_trainer.py
@@ -79,12 +79,31 @@ class MAETrainer(BaseTrainer):
         # Scale learning rate by batch size
         scaled_lr = base_lr * self.batch_size / 256
         
-        self.optimizer = optim.AdamW(
-            self.model.parameters(),
-            lr=scaled_lr,
-            betas=(0.9, 0.95),
-            weight_decay=weight_decay
-        )
+        if self.config.get('use_muon', False):
+            try:
+                from muon import MuonWithAuxAdam
+                hidden_weights = [p for p in self.model.parameters() if p.ndim >= 2]
+                other_params = [p for p in self.model.parameters() if p.ndim < 2]
+                param_groups = [
+                    dict(params=hidden_weights, use_muon=True, lr=scaled_lr, weight_decay=weight_decay),
+                    dict(params=other_params, use_muon=False, lr=scaled_lr, betas=(0.9, 0.95), weight_decay=weight_decay),
+                ]
+                self.optimizer = MuonWithAuxAdam(param_groups)
+            except Exception as e:
+                print(f"Failed to initialize Muon optimizer: {e}. Falling back to AdamW.")
+                self.optimizer = optim.AdamW(
+                    self.model.parameters(),
+                    lr=scaled_lr,
+                    betas=(0.9, 0.95),
+                    weight_decay=weight_decay
+                )
+        else:
+            self.optimizer = optim.AdamW(
+                self.model.parameters(),
+                lr=scaled_lr,
+                betas=(0.9, 0.95),
+                weight_decay=weight_decay
+            )
         
         # Setup learning rate scheduler
         total_epoch = self.config.get('total_epoch', 2000)


### PR DESCRIPTION
## Summary
- add `use_muon` to training config defaults
- integrate Muon optimizer in `MAETrainer`
- update YAML configs to include new option
- add Muon dependency to requirements

## Testing
- `python test/test_basic_framework.py` *(fails: ModuleNotFoundError: No module named 'src')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_688b686169b0832d9a20e2065bf80f1d