### PR TITLE
Fix resume mode epoch handling

### DIFF
--- a/src/core/base_trainer.py
+++ b/src/core/base_trainer.py
@@ -148,7 +148,9 @@ class BaseTrainer(ABC):
             'learning_rates': []
         }
         
-        for epoch in range(num_epochs):
+        start_epoch = self.current_epoch + 1 if self.config.get('resume', False) else 0
+
+        for epoch in range(start_epoch, num_epochs):
             self.current_epoch = epoch
             
             # Training phase


### PR DESCRIPTION
## Summary
- ensure the training loop continues from the loaded epoch when resuming

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b86166054832db201a117d9dd0fc2