### PR TITLE
Add gap waveform dataset

### DIFF
--- a/configs/diffusion_example.yaml
+++ b/configs/diffusion_example.yaml
@@ -75,7 +75,11 @@ diff_params:
     ntaps: 101
 
 data:
-  dataset_type: audio_folder
-  folder: assets
+  dataset_type: gap_waveform
+  flac_path: assets/gapped_audio.wav
+  test_audio_filename: assets/wav_test.wav
   sample_rate: 16000
-  segment_length: 65536
+  gap_percentage: 0.75
+  n_fft: 1024
+  hop_length: 256
+  n_mels: 80

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,6 +1,11 @@
-# Data module for AI training framework
+"""Data module for AI training framework."""
 
 from .mel_spectrogram_dataset import MelSpectrogramDataset
 from .audio_dataset import AudioFolderDataset
+from .gap_waveform_dataset import GapWaveformDataset
 
-__all__ = ['MelSpectrogramDataset', 'AudioFolderDataset']
+__all__ = [
+    'MelSpectrogramDataset',
+    'AudioFolderDataset',
+    'GapWaveformDataset',
+]

--- a/src/data/gap_waveform_dataset.py
+++ b/src/data/gap_waveform_dataset.py
@@ -1,0 +1,37 @@
+"""Waveform dataset for diffusion training.
+
+This dataset shares the same gap detection and cropping logic as
+``MelSpectrogramDataset`` but returns raw waveform segments for
+training diffusion models.
+"""
+
+import random
+from typing import Dict, Any
+import numpy as np
+import torch
+
+from .mel_spectrogram_dataset import MelSpectrogramDataset
+
+
+class GapWaveformDataset(MelSpectrogramDataset):
+    """Dataset returning waveform slices instead of spectrograms."""
+
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(config)
+        # Number of samples corresponding to a crop of ``crop_frames``
+        self.crop_samples = self.crop_frames * self.hop_length
+        if self.wave.shape[0] < self.crop_samples:
+            pad = self.crop_samples - self.wave.shape[0]
+            self.wave = np.pad(self.wave, (0, pad), mode="constant")
+
+    def __getitem__(self, idx: int) -> torch.Tensor:  # type: ignore[override]
+        start = random.choice(self.valid_starts)
+        start_sample = start * self.hop_length
+        end_sample = start_sample + self.crop_samples
+        if end_sample > len(self.wave):
+            pad = end_sample - len(self.wave)
+            wave = np.pad(self.wave, (0, pad), mode="constant")
+        else:
+            wave = self.wave
+        crop = wave[start_sample:end_sample]
+        return torch.from_numpy(crop).float()

--- a/src/factory.py
+++ b/src/factory.py
@@ -60,6 +60,9 @@ class DatasetFactory:
             return MelSpectrogramDataset(config)
         elif dataset_type == 'audio_folder':
             return AudioFolderDataset(config)
+        elif dataset_type == 'gap_waveform':
+            from .data.gap_waveform_dataset import GapWaveformDataset
+            return GapWaveformDataset(config)
         else:
             raise ValueError(f"Unknown dataset type: {dataset_type}")
     


### PR DESCRIPTION
## Summary
- implement `GapWaveformDataset` for diffusion training
- expose the dataset through `DatasetFactory`
- update data module exports
- configure diffusion example to use the new dataset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cd96031f8832da7eb541d35db0c99