### PR TITLE
Implement fallback Snake activation

### DIFF
--- a/src/models/VAE.py
+++ b/src/models/VAE.py
@@ -14,11 +14,22 @@ try:
     from snake.activations import Snake
 except Exception:  # pragma: no cover - fallback if package unavailable
     class Snake(nn.Module):
+        """Fallback Snake activation with trainable frequency parameter."""
+
         def __init__(self, in_features: int, a: float = 1.0, trainable: bool = True):
             super().__init__()
+            init = torch.full((in_features,), a, dtype=torch.float32)
+            if trainable:
+                self.a = nn.Parameter(init)
+            else:
+                self.register_buffer("a", init)
 
-        def forward(self, x: torch.Tensor) -> torch.Tensor:
-            return x
+        def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover - simple formula
+            return torch.where(
+                self.a == 0,
+                x,
+                x + torch.sin(self.a * x) ** 2 / self.a
+            )
 
 
 


### PR DESCRIPTION
## Summary
- provide in-repo Snake activation matching torch-snake when the package is unavailable
- ensure VAE checkpoints with Snake parameters load correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4a1e0e260832d9e21eaea8e56a0dc